### PR TITLE
Changed prompt

### DIFF
--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -51,7 +51,7 @@ class OpenAiService extends ApiService
         $targetLanguage = $this->getLanguage($targetLocale);
 
         $prompt = ($sourceLanguage) ? "Translate the following text from $sourceLanguage " : 'Translate the following text ';
-        $prompt .= "to $targetLanguage, keep html: " . $text;
+        $prompt .= "to $targetLanguage, keep html and only answer with the translated text, if you can not translate it, just return the text i've provided you: " . $text;
 
         $body = [
             'model' => $this->getProviderSettings()->getOpenAiModel(),


### PR DESCRIPTION
We've encountered some problems with short strings, where chat-gpt answered with some additional text instead of just the translation. We've added some additional instructions to the prompt, which fixed the issue for us.