### PR TITLE
Correct a few issues found on the Translate Review screen.

### DIFF
--- a/src/templates/_translate/review.twig
+++ b/src/templates/_translate/review.twig
@@ -88,7 +88,7 @@
                     <h2>Ignore Fields</h2>
                 </legend>
 
-                {% set fields = element.type.fieldLayout.customFields %}
+                {% set fields = element.fieldLayout.customFields %}
                 {% set fieldsOptions = [{label: "Title", value: "title"}]
                     |merge(fields|map(field => {label: "#{field.name} (#{field.handle})", value: field.handle})) %}
 


### PR DESCRIPTION
Hi! I was doing some work for a client that uses this plugin, and found a few issues. They're relatively minor, so I've grouped them in a single PR. Let me know if you'd like me to separate these into discrete branches, or if you have questions/thoughts. (Didn't see any specific branching flow used, but I could've missed it.) Thanks!

## Checkbox fields
To 'get' the whitespace that Craft uses for label/input combinations, we need to use the `Field` version of checkbox groups. Here's a before/after screenshot:

#### Before
<img width="403" height="285" alt="Screenshot 2025-12-04 at 9 02 23 AM" src="https://github.com/user-attachments/assets/60dc56db-ee4e-404f-8922-9d44a519dacc" />


#### After
<img width="421" height="289" alt="Screenshot 2025-12-04 at 9 02 34 AM" src="https://github.com/user-attachments/assets/7818e7a7-28c7-4615-9a03-09480ac6d179" />

## Displaying asset information
When attempting to view the Translate Review screen when an Asset is selected, several errors were thrown (`Calling unknown method: craft\elements\Asset::section()`, `Calling unknown method: craft\elements\Asset::type()`, and similar).

This PR adds a fallback that checks relevant fields, if the element isn't the expected `Entry` type. (Specifically, the Asset's Volume is displayed instead of its section name, and the volume's `alt` text translation method.)

#### Screenshot of an Asset in Translate Review screen
<img width="887" height="378" alt="Screenshot 2025-12-04 at 9 30 43 AM" src="https://github.com/user-attachments/assets/bcdb63ea-c748-435e-8084-7d9cd437758a" />

## Get the fieldLayout directly
Since both Assets and Entries (as well as most other Elements) implement the`ElementInterface`, we can safely use the `getFieldLayout()` method (via `.fieldLayout`) in our logic.