### PR TITLE
feat(openai): support OpenAI-compatible endpoints (base URL + custom model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ For now, we support these API services:
 - Google Cloud Translation v2 - Create an API key in your [Cloud Console](https://console.cloud.google.com/)
 - Google Cloud Translation v3 - Create a Service Account your [Cloud Console](https://console.cloud.google.com/iam-admin/serviceaccounts)
 - OpenAI (ChatGPT) - Create an API key in at [OpenAI](https://platform.openai.com/)
+  - also supports any [OpenAI-compatible endpoint](#openai-compatible-providers) (Azure OpenAI, Ollama, Groq, Mistral, Infomaniak AI Service, …)
+
+### OpenAI-compatible providers
+
+The **OpenAI API** provider supports a configurable base URL and custom model name, allowing you to point it at any OpenAI-compatible endpoint.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **API Base URL** | Base URL of the API endpoint | `https://api.openai.com/v1` |
+| **API model** | Model dropdown, or select "Custom" to enter a free-text model identifier | `gpt-4o` |
+| **Custom model name** | Free-text model identifier (shown when "Custom" is selected) | — |
+
+Both the base URL and model fields support Craft environment variables (e.g. `$OPENAI_BASE_URL`).
+
+#### Example: Infomaniak AI Service
+
+In your `.env`:
+
+```bash
+OPENAI_BASE_URL="https://api.infomaniak.com/2/ai/{product_id}/openai/v1"
+OPENAI_API_KEY="your-infomaniak-api-token"
+```
+
+In the plugin settings: set Base URL to `$OPENAI_BASE_URL`, API Key to `$OPENAI_API_KEY`, select **Custom** as the model and enter e.g. `mistral3` or `qwen3`.
 
 ## Roadmap
 

--- a/src/records/ProviderSettings.php
+++ b/src/records/ProviderSettings.php
@@ -120,13 +120,41 @@ class ProviderSettings extends ActiveRecord
     }
 
     /**
+     * Base URL for OpenAI-compatible API
+     * Defaults to the official OpenAI API. Override to use any compatible provider
+     * (e.g. Infomaniak, Ollama, Azure OpenAI, Groq, Mistral).
+     * @return string
+     */
+    public function getOpenAiBaseUrl(): string
+    {
+        $value = $this->getSetting('openAiBaseUrl', '');
+        return !empty($value) ? rtrim($value, '/') : 'https://api.openai.com/v1';
+    }
+
+    /**
+     * Custom model name that overrides the dropdown selection.
+     * Useful for non-OpenAI providers that use different model identifiers.
+     * @return string|null
+     */
+    public function getOpenAiCustomModel(): ?string
+    {
+        $value = $this->getSetting('openAiCustomModel', null);
+        return !empty($value) ? $value : null;
+    }
+
+    /**
      * Model for the OpenAI API
      * read more: https://platform.openai.com/docs/models/model-endpoint-compatibility
      * @return string
      */
     public function getOpenAiModel(): string
     {
-        return $this->getSetting('openAiModel', 'gpt-4o');
+        $dropdown = $this->getSetting('openAiModel', 'gpt-4o');
+        if ($dropdown === 'custom') {
+            $custom = $this->getOpenAiCustomModel();
+            return !empty($custom) ? $custom : 'gpt-4o';
+        }
+        return $dropdown;
     }
 
     /**

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -12,13 +12,18 @@ class OpenAiService extends ApiService
 
     public function getName(): string
     {
+        $baseUrl = $this->getBaseUrl();
+        if (!str_contains($baseUrl, 'api.openai.com')) {
+            $host = parse_url($baseUrl, PHP_URL_HOST);
+            return 'OpenAI Compatible' . ($host ? " ($host)" : '');
+        }
         return 'ChatGPT (Open AI)';
     }
 
     public function isConnected(): bool
     {
         try {
-            return $this->getClient()->get('https://api.openai.com/v1/models')->getStatusCode() == 200;
+            return $this->getClient()->get($this->getBaseUrl() . '/models')->getStatusCode() == 200;
         } catch (\Throwable $exception) {
             return false;
         }
@@ -57,8 +62,10 @@ class OpenAiService extends ApiService
             $sourceLanguage ?? '[guess the language]', $targetLanguage, $text
         ], $prompt);
 
+        $model = App::parseEnv($this->getProviderSettings()->getOpenAiModel());
+
         $body = [
-            'model' => $this->getProviderSettings()->getOpenAiModel(),
+            'model' => $model,
             'messages' => [
                 [
                     'role' => 'user',
@@ -68,7 +75,13 @@ class OpenAiService extends ApiService
             'temperature' => floatval($this->getProviderSettings()->getOpenAiTemperature()),
         ];
 
-        $response = $this->getClient()->post('https://api.openai.com/v1/chat/completions', ['json' => $body]);
+        try {
+            $response = $this->getClient()->post($this->getBaseUrl() . '/chat/completions', ['json' => $body]);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $responseBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : 'no response body';
+            MultiTranslator::error('OpenAI API error: ' . $responseBody);
+            throw $e;
+        }
 
         if ($response->getStatusCode() < 300) {
 
@@ -92,5 +105,13 @@ class OpenAiService extends ApiService
             return null;
         }
         return locale_get_display_name($locale, 'en');
+    }
+
+    /**
+     * Get the base URL for the OpenAI-compatible API, with env var support.
+     */
+    private function getBaseUrl(): string
+    {
+        return App::parseEnv($this->getProviderSettings()->getOpenAiBaseUrl());
     }
 }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -159,9 +159,18 @@
                 </legend>
 
                 {{ forms.autosuggestfield({
-                    label: 'Open AI API Key',
+                    label: 'API Base URL',
+                    name: 'openAiBaseUrl',
+                    instructions: 'Base URL for the API. Leave empty for the official OpenAI API. Set a custom URL to use any OpenAI-compatible provider (e.g. Infomaniak, Ollama, Azure OpenAI, Groq, Mistral).',
+                    suggestEnvVars: true,
+                    value: settings.openAiBaseUrl,
+                    placeholder: 'https://api.openai.com/v1',
+                }) }}
+
+                {{ forms.autosuggestfield({
+                    label: 'API Key',
                     name: 'openAiKey',
-                    instructions: 'Create an API Key from your [OpenAI platform](https://platform.openai.com/api-keys)',
+                    instructions: 'API key or bearer token for the endpoint.',
                     suggestEnvVars: true,
                     value: settings.openAiKey,
                 }) }}
@@ -179,10 +188,10 @@
 
                 {{ forms.selectField({
                     label: "API model",
-                    instructions: "",
+                    instructions: "Select a model. Choose 'Custom' to enter a custom model name for non-OpenAI providers.",
                     id: "openAiModel",
                     name: "openAiModel",
-                    value: settings.openAiModel,
+                    value: settings.getSetting('openAiModel', 'gpt-4o'),
                     options: [
                         {'label': 'GPT 3.5 Turbo', 'value': 'gpt-3.5-turbo'},
                         {'label': 'GPT 4', 'value': 'gpt-4'},
@@ -197,9 +206,23 @@
                         {'label': 'GPT 5.4', 'value': 'gpt-5.4'},
                         {'label': 'GPT 5.4 Mini', 'value': 'gpt-5.4-mini'},
                         {'label': 'GPT 5.4 Nano', 'value': 'gpt-5.4-nano'},
+                        {'label': 'Custom', 'value': 'custom'},
                     ],
+                    toggle: true,
+                    targetPrefix: 'openai-model-',
                     errors: settings.getErrors("openAiModel"),
                 }) }}
+
+                <div id="openai-model-custom"{% if settings.getSetting('openAiModel', 'gpt-4o') != 'custom' %} class="hidden"{% endif %}>
+                    {{ forms.autosuggestfield({
+                        label: 'Custom model name',
+                        name: 'openAiCustomModel',
+                        instructions: 'Enter the model identifier for your provider (e.g. `mistral3`, `qwen3`, `llama3`).',
+                        suggestEnvVars: true,
+                        value: settings.openAiCustomModel,
+                        placeholder: '',
+                    }) }}
+                </div>
 
                 {{ forms.textfield({
                     label: 'Custom prompt',


### PR DESCRIPTION
## Summary

Adds support for **OpenAI-compatible API endpoints** to the existing OpenAI provider, so the plugin can be pointed at services like Azure OpenAI, Ollama, Groq, Mistral, Infomaniak AI Service, OpenRouter, etc., without needing a separate provider.

This is fully backwards-compatible: existing installs keep talking to `https://api.openai.com/v1` with their current model.

## What's new

Two new fields on the OpenAI provider settings:

| Setting | Description | Default |
|---------|-------------|---------|
| **API Base URL** | Base URL of the API endpoint | `https://api.openai.com/v1` |
| **Custom model name** | Free-text model identifier, shown when the model dropdown is set to **Custom** | — |

Both fields support Craft environment variables (e.g. `$OPENAI_BASE_URL`), matching the existing API-key field.

## Changes

- `ProviderSettings`: add `openAiBaseUrl` and `openAiCustomModel`, with sensible defaults and env-var parsing
- `OpenAiService`: pass the configured base URL to the OpenAI client; resolve the model from the dropdown or the custom field; log API errors so failures are easier to diagnose
- `settings.twig`: new Base URL field; conditionally show the Custom model field only when "Custom" is selected in the dropdown
- `README.md`: document the new settings with an Infomaniak example

## Backwards compatibility

- Default base URL = `https://api.openai.com/v1` (unchanged behaviour)
- Existing model selection continues to work; the "Custom" option is purely additive
- No DB migration needed (settings are stored in the existing JSON column)

## Testing

We've been running this in production at Prolog Digital against the Infomaniak AI Service (Mistral / Qwen models) for several weeks without regressions on standard OpenAI usage.

Happy to adjust naming, UI copy, or split commits further if preferred.
