### PR TITLE
Fix UnknownPropertyException for translatable Matrix block titles

### DIFF
--- a/src/services/TranslateService.php
+++ b/src/services/TranslateService.php
@@ -240,7 +240,15 @@ class TranslateService extends Component
             foreach ($translatedMatrixValues as $matrixFieldHandle => $value) {
                 // only set translated values in matrix array
                 if ($value && isset($serialized[$matrixElement->id])) {
-                    $serialized[$matrixElement->id]['fields'][$matrixFieldHandle] = $value;
+                    // title/slug are native attributes on the nested entry — set them at the
+                    // block root, not inside `fields`. Otherwise Craft's
+                    // Matrix::_createEntriesFromSerializedData() throws UnknownPropertyException
+                    // when it iterates the `fields` array and calls setFieldValue('title', ...).
+                    if (in_array($matrixFieldHandle, ['title', 'slug'], true)) {
+                        $serialized[$matrixElement->id][$matrixFieldHandle] = $value;
+                    } else {
+                        $serialized[$matrixElement->id]['fields'][$matrixFieldHandle] = $value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

When translating an element whose Matrix field contains nested entry types with **translatable titles**, the `BulkTranslateJob` (or `TranslateJob`) fails with:

```
yii\base\UnknownPropertyException: Setting unknown property: craft\behaviors\CustomFieldBehavior::title
```

Stack trace (abridged):

```
TranslateService->translateElement()
  -> Drafts::saveElementAsDraft()
    -> Element::validate()
      -> Matrix::normalizeValue()
        -> Matrix::_createEntriesFromSerializedData()
          -> Element::setFieldValue('title', ...)
            -> CustomFieldBehavior::__set('title')   <-- throws
```

## Root cause

In `TranslateService::translateMatrixField()`, every value returned from `translateElementFields()` is dumped into the block's `fields` array:

```php
$serialized[$matrixElement->id]['fields'][$matrixFieldHandle] = $value;
```

But `translateElementFields()` includes `'title'` in its return when the nested entry's title is translatable (`getIsTitleTranslatable()`). Craft's `Matrix::_createEntriesFromSerializedData()` expects `title` at the **block root**, not inside `fields` — see [Matrix.php#L1976](https://github.com/craftcms/cms/blob/5.x/src/fields/Matrix.php). When it iterates `fields` and hits `title`, it routes through `setFieldValue('title', ...)` -> `CustomFieldBehavior::__set('title')`, which throws because `title` isn't a custom field.

The surrounding `try/catch` in `Matrix.php` only catches `InvalidFieldException`, so `UnknownPropertyException` escapes and kills the queue job.

The top-level `translateElement()` already special-cases `title` ([line 60](https://github.com/digitalpulsebe/craft-multi-translator/blob/craft-4-develop/src/services/TranslateService.php#L60)) — this PR just brings `translateMatrixField()` in line with that.

Note: this is already handled correctly in the 2.x serializer-based architecture on `develop`, but `craft-4-develop` (1.x) still has the bug.

## Fix

Special-case `title` (and `slug`, for the same reason) so they go to the block root instead of `fields`.

## Reproduction

1. Create an entry type used inside a Matrix field, with the title field shown and `translationMethod` set to translatable per-site.
2. Add at least one block of that entry type to a Matrix field on a translatable entry.
3. Run a Multi Translator translation on the parent entry to a different site.
4. Without this fix: the queue job fails with `UnknownPropertyException: ... CustomFieldBehavior::title`. With the fix: the draft is created and the nested block title is translated.

## Notes for reviewers

Opened as draft for Digital Pulse to confirm the approach matches their preference (e.g. whether `slug` should also be hoisted, or only `title`).