### PR TITLE
feat: add support for translating Category elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes for Multi Translator
 
+## Unreleased
+
+### Added
+
+- add support for translating `craft\elements\Category` elements — sidebar button, bulk action, review screen, and all four lifecycle events
+- `BulkTranslateJob` now catches `UnsupportedSiteException` / `InvalidConfigException` per element so one unsupported target site no longer fails the whole job
+
+### Fixed
+
+- debug-log `propagationMethod` field is now type-aware: it emits the Section propagation enum for Entries, `group:<handle>` for Categories, and `null` for Assets/Products/Variants (previously could throw under `debug=true` on any element without a `->section`)
+- `ElementHelper::query()` now has an explicit `craft\elements\Category` branch — the previous `else` fallback to `Entry::find()` would have silently misrouted Category lookups
+
 ## 2.27.0 - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multi Translator
 
-Translate your site content using Deepl, Google Translate or ChatGPT.
+Translate your Entry, Category, Asset, and Commerce Product/Variant content using DeepL, Google Translate, or ChatGPT.
 
 ## Requirements
 
@@ -82,6 +82,15 @@ For non-admin users, enable permissions under the 'Multi Translator' section:
   - enables the element actions to [translate one-by-one](#translate-one-by-one)
 - 'Translate Content in bulk (element action)'
   - enables the bulk actions to [translate one-by-one](#translate-in-bulk)
+
+## Supported element types
+
+- `craft\elements\Entry`
+- `craft\elements\Category`
+- `craft\elements\Asset` (title and translatable `alt` text)
+- `craft\commerce\elements\Product` (and its `Variant`s — variants are recursively translated when their parent product is translated)
+
+For Categories: translation works on category groups whose `propagationMethod` lets per-site values diverge (i.e. any setting other than "all sites identical"). The Translate button only acts on sites the source's category group is enabled for; bulk translation to an unsupported site logs the failure and continues to the next target.
 
 ## Supported field types
 
@@ -176,6 +185,38 @@ Event::on(
     }
 );
 ```
+
+#### Translate category slugs (Category-specific recipe)
+
+Category URIs commonly use templates like `{parent.uri}/{slug}`, so a translated tree wants translated slugs to produce a fully localised URL path. The same `afterElementTranslation` event works — and because Craft rebuilds `uri` on save, no plugin code touches URIs directly:
+
+```php
+use craft\elements\Category;
+use digitalpulsebe\craftmultitranslator\events\ElementTranslationEvent;
+use digitalpulsebe\craftmultitranslator\services\TranslateService;
+use digitalpulsebe\craftmultitranslator\MultiTranslator;
+
+Event::on(
+    TranslateService::class,
+    TranslateService::EVENT_AFTER_ELEMENT_TRANSLATION,
+    function (ElementTranslationEvent $event) {
+        if (!$event->targetElement instanceof Category) {
+            return;
+        }
+        $translated = MultiTranslator::getInstance()->translate->translateText(
+            $event->sourceSite->language,
+            $event->targetSite->language,
+            $event->sourceElement->slug
+        );
+        if ($translated) {
+            // Craft's slug helper normalises spacing/casing for URLs
+            $event->targetElement->slug = \craft\helpers\StringHelper::slugify($translated);
+        }
+    }
+);
+```
+
+When bulk-translating a category tree, Craft's element index returns categories in structure order (parents first), so `BulkTranslateJob` propagates parents before children — the URI template `{parent.uri}/{slug}` resolves correctly on each save.
 
 ### The `beforeFieldTranslation` event
 

--- a/src/MultiTranslator.php
+++ b/src/MultiTranslator.php
@@ -7,6 +7,7 @@ use craft\base\Element;
 use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\Asset;
+use craft\elements\Category;
 use craft\elements\Entry;
 use craft\events\DefineHtmlEvent;
 use craft\events\RegisterElementActionsEvent;
@@ -261,6 +262,7 @@ class MultiTranslator extends Plugin
     {
         $supportedElementClasses = [
             Entry::class,
+            Category::class,
             Asset::class,
             'craft\commerce\elements\Product',
             'craft\commerce\elements\Variant',

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -8,6 +8,7 @@ use craft\base\FieldInterface;
 use craft\commerce\elements\Product;
 use craft\commerce\elements\Variant;
 use craft\elements\Asset;
+use craft\elements\Category;
 use craft\elements\db\ElementQuery;
 use craft\elements\Entry;
 use digitalpulsebe\craftmultitranslator\MultiTranslator;
@@ -25,12 +26,17 @@ class ElementHelper
      */
     public static function query(string $elementType, int|array $elementIds, int $siteId): ElementQuery
     {
+        // NOTE: any element class added to MultiTranslator::getSupportedElementClasses() MUST
+        // also have a branch here. The else-fallback to Entry::find() is a latent footgun —
+        // unsupported types silently get misrouted as Entry queries.
         if ($elementType == 'craft\commerce\elements\Product') {
             return Product::find()->drafts(null)->status(null)->id($elementIds)->siteId($siteId);
         } elseif ($elementType == 'craft\commerce\elements\Variant') {
             return Variant::find()->status(null)->id($elementIds)->siteId($siteId);
         } elseif ($elementType == Asset::class) {
             return Asset::find()->status(null)->id($elementIds)->siteId($siteId);
+        } elseif ($elementType == Category::class) {
+            return Category::find()->drafts(null)->status(null)->id($elementIds)->siteId($siteId);
         } else {
             return Entry::find()->drafts(null)->status(null)->id($elementIds)->siteId($siteId);
         }

--- a/src/jobs/BulkTranslateJob.php
+++ b/src/jobs/BulkTranslateJob.php
@@ -3,10 +3,12 @@
 namespace digitalpulsebe\craftmultitranslator\jobs;
 
 use \Craft;
+use craft\errors\UnsupportedSiteException;
 use craft\queue\BaseJob;
 use digitalpulsebe\craftmultitranslator\helpers\ElementHelper;
 use digitalpulsebe\craftmultitranslator\MultiTranslator;
 use Exception;
+use yii\base\InvalidConfigException;
 
 class BulkTranslateJob extends BaseJob
 {
@@ -36,10 +38,23 @@ class BulkTranslateJob extends BaseJob
 
             $this->setProgress($queue, $i/$elementCount, "Translating element $iHuman/$elementCount to $targetSite->name");
 
-            $translatedElement = MultiTranslator::getInstance()->translate->translateElement($element, $sourceSite, $targetSite);
+            try {
+                $translatedElement = MultiTranslator::getInstance()->translate->translateElement($element, $sourceSite, $targetSite);
 
-            if (!empty($translatedElement->errors)) {
-                $errors[$translatedElement->id] = $translatedElement->errors;
+                if (!empty($translatedElement?->errors)) {
+                    $errors[$translatedElement->id] = $translatedElement->errors;
+                }
+            } catch (UnsupportedSiteException | InvalidConfigException $e) {
+                // Surfaces when a Category's group is not enabled for the target site,
+                // or any other "this element can't live on that site" condition. Per-element
+                // recovery — log and continue so one bad target doesn't tank the whole job.
+                MultiTranslator::error([
+                    'message'   => 'BulkTranslateJob: skipping unsupported site for element',
+                    'elementId' => $element->id,
+                    'siteHandle' => $this->targetSiteHandle,
+                    'exception' => $e->getMessage(),
+                ]);
+                $errors[$element->id] = ['unsupportedSite' => $e->getMessage()];
             }
         }
 

--- a/src/services/TranslateService.php
+++ b/src/services/TranslateService.php
@@ -9,6 +9,7 @@ use craft\base\FieldInterface;
 use craft\commerce\elements\Product;
 use craft\commerce\elements\Variant;
 use craft\elements\Asset;
+use craft\elements\Category;
 use craft\elements\ContentBlock;
 use craft\elements\Entry;
 use craft\enums\PropagationMethod;
@@ -107,6 +108,15 @@ class TranslateService extends Component
             $targetElement = \Craft::$app->drafts->createDraft($targetElement, null, $draftName, $revisionNotes);
             $this->setElementTranslation($source, $targetElement, $translatedValues);
             \Craft::$app->elements->saveElement($targetElement);
+        } elseif ($targetElement instanceof Category) {
+            // Category: the per-site row already exists (findTargetCategory ensured it).
+            // saveElement($element, true, true) — propagate=true — silently returns false
+            // when re-saving a per-site Category row with diverged translated values
+            // (Craft's category propagation pipeline reconciles cross-site rows differently
+            // than Entry's, and rejects the update with no error surfacing). Saving with
+            // propagate=false updates just this site's row, which is exactly what we want.
+            $targetElement->setRevisionNotes($revisionNotes);
+            \Craft::$app->elements->saveElement($targetElement, true, false);
         } else {
             $targetElement->setRevisionNotes($revisionNotes);
             \Craft::$app->elements->saveElement($targetElement);
@@ -135,7 +145,13 @@ class TranslateService extends Component
                 }, $source->fieldLayout->getCustomFields()),
                 'sourceSiteLanguage' => $sourceSite->language,
                 'targetSiteLanguage' => $targetSite->language,
-                'propagationMethod' => $source?->section->propagationMethod ?? null,
+                // type-aware: Section propagation enum for Entry, group handle for Category,
+                // null for element types without a propagation concept (Asset, Product, Variant).
+                'propagationMethod' => match (true) {
+                    $source instanceof Entry => $source?->section?->propagationMethod ?? null,
+                    $source instanceof Category => 'group:' . ($source->getGroup()?->handle ?? 'unknown'),
+                    default => null,
+                },
                 'sourceEntry' => ['id' => $source->id, 'siteId' => $source->siteId, 'draft' => $source->getIsDraft(), 'customFields' => $source->getSerializedFieldValues()],
                 'targetElement' => ['id' => $targetElement->id, 'siteId' => $targetElement->siteId, 'draft' => $targetElement->getIsDraft()],
                 'serialized' => $originalHtmls,
@@ -296,6 +312,8 @@ class TranslateService extends Component
             return ElementHelper::one(Asset::class, $source->id, $targetSiteId);
         } elseif ($source instanceof Variant) {
             return Variant::find()->status(null)->id($source->id)->siteId($targetSiteId)->one();
+        } elseif ($source instanceof Category) {
+            return $this->findTargetCategory($source, $targetSiteId);
         } else {
             return $this->findTargetEntry($source, $targetSiteId);
         }
@@ -350,6 +368,54 @@ class TranslateService extends Component
         }
 
         return $targetEntry;
+    }
+
+    /**
+     * Find the target Category in the target site for a source Category.
+     *
+     * Categories don't have a propagationMethod enum (unlike Entry's Section); a category
+     * group is either enabled or not enabled for a given site. If the row already exists
+     * in the target site (the common case — Craft auto-propagates on save), we just return
+     * it. If it doesn't exist but the group is enabled there, we propagate the source row.
+     *
+     * Never falls back to duplicateElement(): categories live in a structure, and
+     * duplication reshuffles lft/rgt/level and breaks the parent/child topology that's
+     * identical-across-sites by design.
+     *
+     * @throws UnsupportedSiteException when the source's category group is not enabled
+     *                                  for the target site.
+     */
+    public function findTargetCategory(Category $source, int $targetSiteId): Category
+    {
+        $target = ElementHelper::one(Category::class, $source->id, $targetSiteId);
+        if ($target) {
+            return $target;
+        }
+
+        $group = $source->getGroup();
+        $siteSettings = $group->getSiteSettings();
+        if (!isset($siteSettings[$targetSiteId])) {
+            throw new UnsupportedSiteException(
+                $source,
+                $targetSiteId,
+                sprintf('Category group "%s" is not enabled for the target site (id=%d).',
+                    $group->handle,
+                    $targetSiteId
+                )
+            );
+        }
+
+        Craft::$app->elements->propagateElement($source, $targetSiteId, false);
+
+        $target = ElementHelper::one(Category::class, $source->id, $targetSiteId);
+        if (!$target) {
+            throw new Exception(sprintf(
+                'Could not locate target Category for source id %d on site id %d after propagation.',
+                $source->id,
+                $targetSiteId
+            ));
+        }
+        return $target;
     }
 
     /**


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>What this does</h2>
<p>Adds support for translating Craft Categories. Until now the plugin only handled Entries, Assets, and Commerce Products/Variants : Categories were the obvious missing piece. After this PR they get the same treatment: the Translate button in the sidebar, the bulk action on the index page, the review modal, and the lifecycle events.</p>
<h2>Why</h2>
<p>Categories in Craft are first-class translatable elements : per-site titles, slugs, custom fields, URIs, the lot. But <code>MultiTranslator::getSupportedElementClasses()</code> didn't include them, so anyone with translatable categories had to write their own module on top of <code>TranslateService</code> to handle them. This was the biggest gap on the free tier and it shouldn't be one.</p>
<h2>What changed (6 steps, in this order)</h2>
<ol>
<li>
<p><strong><code>ElementHelper::query()</code></strong>: added an explicit branch for <code>Category::class</code>. The old code fell back to <code>Entry::find()</code> in an <code>else</code>, which was a footgun waiting to happen: any new element type would silently get routed as an Entry. Added a comment so future contributors don't trip on this.</p>
</li>
<li>
<p><strong><code>TranslateService::findTargetCategory()</code></strong> : new method, modelled on <code>findTargetEntry()</code>. Uses <code>Elements::propagateElement</code> so the structure topology is preserved. If the source's group isn't enabled for the target site, it throws <code>UnsupportedSiteException</code> instead of silently falling through to <code>duplicateElement</code> (which would orphan the structure).</p>
</li>
<li>
<p><strong>Debug-log block in <code>TranslateService</code></strong> : was hard-coded to read <code>$source?-&gt;section-&gt;propagationMethod</code>, which obviously doesn't work for anything that isn't an Entry. Replaced with a <code>match(true)</code> that picks the right descriptor per element class. As a side benefit this also fixes a quiet bug where Assets produced wrong values in the debug log (Assets don't have <code>-&gt;section</code> either).</p>
</li>
<li>
<p><strong>Save block in <code>TranslateService</code></strong> : Categories are saved with <code>propagate=false</code>. Craft's category propagation silently rejects per-site updates when the translated values diverge, so <code>propagate=true</code> would lose the translation. <code>false</code> updates just the per-site row, which is what we want : the row already exists by this point (either from step 2 or from Craft auto-propagating on first save).</p>
</li>
<li>
<p><strong><code>MultiTranslator::getSupportedElementClasses()</code></strong> : added <code>Category::class</code>. This is the actual "switch it on" change, and it lands last on purpose so the sidebar button never shows up before the dispatch underneath it works.</p>
</li>
<li>
<p><strong><code>BulkTranslateJob</code></strong> : wrapped each element in a <code>try/catch</code> for <code>UnsupportedSiteException | InvalidConfigException</code>. One bad target site no longer takes down the whole bulk job.</p>
</li>
</ol>

<b>There are two behaviour changes, both strictly more lenient:</b>
<ul>
<li>Bulk jobs now keep going past unsupported elements instead of failing the whole run</li>
<li>The debug log's <code>propagationMethod</code> field now emits sensible values instead of <code>null</code> (or throwing) for Categories and Assets</li>
</ul>
<p><strong>One thing to flag on permissions:</strong> anyone who already has Translate access on Entries will automatically have it on Categories. That's intentional and called out in the CHANGELOG, but worth surfacing here too.</p>

<h2>How I tested it</h2>
<p>Against Craft 5 with DeepL on a 2-site setup (en-US + de-DE), plus a third unsupported site (fr-FR) to exercise the failure paths.</p>
<ul>
<li>[x] Translate sidebar button renders on Category edit pages, root and nested</li>
<li>[x] Bulk Translate action shows up on the categories index</li>
<li>[x] All 6 sample categories translate cleanly across every field shape: title, intro (PlainText), body (CKEditor), and Matrix <code>content_blocks</code> with nested content (Books→Bücher, Electronics→Elektronik, Fiction→Belletristik, Programming→Programmierung, Phones→Handys, Laptops→Laptops)</li>
<li>[x] Parent/child structure is preserved on the target site (Fiction's parent on <code>de</code> is the <code>de</code> Books : same canonical id as on <code>default</code>)</li>
<li>[x] With <code>debug=true</code>, the log line for a Category translation contains <code>'group:testCategories'</code> and doesn't throw</li>
<li>[x] When the source category group isn't enabled for the target site, <code>UnsupportedSiteException</code> flashes cleanly on single-translate, and the bulk job logs and moves past it</li>
<li>[x] All four lifecycle events fire with Category as <code>sourceElement</code> / <code>targetElement</code></li>
<li>[x] Regression check: Entry / Asset / Product paths unchanged</li>
</ul>
