### PR TITLE
ChatGPT/OpenAI Vectore Store ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes for Multi Translator
 
+## Unreleased
+
+### Added
+
+- OpenAI: optional Vector Store ID enables File Search over glossaries, terminology and style guides via the OpenAI Responses API. Activated only when a Vector Store ID is set on the official `api.openai.com` endpoint; all existing setups are unaffected.
+- OpenAI: optional Prompt ID references a centrally managed prompt from OpenAI Prompt Management via the Responses API. Prompt ID and Vector Store ID can be combined (prompt = behaviour, Vector Store = knowledge). Activated only on the official `api.openai.com` endpoint; all existing setups are unaffected.
+
 ## 2.28.3 - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Added
 
-- OpenAI: optional Vector Store ID enables File Search over glossaries, terminology and style guides via the OpenAI Responses API. Activated only when a Vector Store ID is set on the official `api.openai.com` endpoint; all existing setups are unaffected.
-- OpenAI: optional Prompt ID references a centrally managed prompt from OpenAI Prompt Management via the Responses API. Prompt ID and Vector Store ID can be combined (prompt = behaviour, Vector Store = knowledge). Activated only on the official `api.openai.com` endpoint; all existing setups are unaffected.
+- OpenAI: optional Vector Store ID enables File Search over glossaries, terminology and style guides via the OpenAI Responses API. The existing custom prompt is sent as the request input and complements the Vector Store. Activated only when a Vector Store ID is set on the official `api.openai.com` endpoint; all existing setups are unaffected.
 
 ## 2.28.3 - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -71,22 +71,11 @@ When using the official OpenAI endpoint you can connect a [Vector Store](https:/
 | **Vector Store ID** | Optional OpenAI Vector Store ID (e.g. `vs_...`). When set, the [Responses API](https://platform.openai.com/docs/api-reference/responses) with File Search is used instead of Chat Completions. Supports environment variables. | — |
 | **Enable File Search** | `Auto` uses File Search whenever a Vector Store ID is set on the official endpoint; `Off` forces the legacy Chat Completions API. | `Auto` |
 
-### Prompt Management (Prompt IDs)
-
-On the official OpenAI endpoint you can reference a centrally managed prompt from [OpenAI Prompt Management](https://platform.openai.com/docs/guides/prompt-engineering) instead of maintaining the full prompt in Craft. The stored prompt holds the translation *behaviour* (output rules, HTML handling, instruction to use File Search); the plugin still sends the source/target languages and text dynamically as the request input.
-
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **Prompt ID** | Optional OpenAI Prompt ID (e.g. `pmpt_...`). When set, the Responses API is used with the stored prompt. Supports environment variables. | — |
-| **Prompt version** | Optional. Pin a specific stored prompt version; leave empty to use the currently published version. | — |
-
-Prompt ID and Vector Store ID can be combined: the prompt defines behaviour, the Vector Store supplies knowledge (terminology, glossaries, style guides).
-
 Notes:
 
-- Prompt Management and File Search are OpenAI-specific: they are only used on the official `api.openai.com` endpoint and are ignored for OpenAI-compatible providers.
-- Leaving both the Prompt ID and Vector Store ID empty keeps the existing Chat Completions behaviour unchanged.
-- Your existing prompt is still used and is sent as the request input; a Vector Store or stored prompt complements it, it does not replace it. When using a stored prompt, keep the target language out of the stored prompt — the plugin generates it dynamically.
+- File Search is OpenAI-specific: it is only used on the official `api.openai.com` endpoint and is ignored for OpenAI-compatible providers.
+- Leaving the Vector Store ID empty keeps the existing Chat Completions behaviour unchanged.
+- Your existing custom prompt (the **Custom prompt** field) is still used and is sent as the request input; the Vector Store complements the prompt, it does not replace it. Keep the prompt small and stable (behaviour, HTML/output rules) and maintain terminology and glossaries in the Vector Store.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,32 @@ OPENAI_API_KEY="your-infomaniak-api-token"
 
 In the plugin settings: set Base URL to `$OPENAI_BASE_URL`, API Key to `$OPENAI_API_KEY`, select **Custom** as the model and enter e.g. `mistral3` or `qwen3`.
 
+### Vector Store (File Search)
+
+When using the official OpenAI endpoint you can connect a [Vector Store](https://platform.openai.com/docs/guides/tools-file-search) to enrich translations with your own glossaries, terminology, preferred/forbidden translations and writing guidelines, maintained centrally in OpenAI rather than in Craft.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **Vector Store ID** | Optional OpenAI Vector Store ID (e.g. `vs_...`). When set, the [Responses API](https://platform.openai.com/docs/api-reference/responses) with File Search is used instead of Chat Completions. Supports environment variables. | — |
+| **Enable File Search** | `Auto` uses File Search whenever a Vector Store ID is set on the official endpoint; `Off` forces the legacy Chat Completions API. | `Auto` |
+
+### Prompt Management (Prompt IDs)
+
+On the official OpenAI endpoint you can reference a centrally managed prompt from [OpenAI Prompt Management](https://platform.openai.com/docs/guides/prompt-engineering) instead of maintaining the full prompt in Craft. The stored prompt holds the translation *behaviour* (output rules, HTML handling, instruction to use File Search); the plugin still sends the source/target languages and text dynamically as the request input.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **Prompt ID** | Optional OpenAI Prompt ID (e.g. `pmpt_...`). When set, the Responses API is used with the stored prompt. Supports environment variables. | — |
+| **Prompt version** | Optional. Pin a specific stored prompt version; leave empty to use the currently published version. | — |
+
+Prompt ID and Vector Store ID can be combined: the prompt defines behaviour, the Vector Store supplies knowledge (terminology, glossaries, style guides).
+
+Notes:
+
+- Prompt Management and File Search are OpenAI-specific: they are only used on the official `api.openai.com` endpoint and are ignored for OpenAI-compatible providers.
+- Leaving both the Prompt ID and Vector Store ID empty keeps the existing Chat Completions behaviour unchanged.
+- Your existing prompt is still used and is sent as the request input; a Vector Store or stored prompt complements it, it does not replace it. When using a stored prompt, keep the target language out of the stored prompt — the plugin generates it dynamically.
+
 ## Roadmap
 
 Please let us know which API's and features are desired for this plugin!

--- a/src/providers/OpenAiProvider.php
+++ b/src/providers/OpenAiProvider.php
@@ -69,6 +69,21 @@ class OpenAiProvider extends Provider
             return null;
         }
 
+        $prompt = $this->buildPrompt($sourceLocale, $targetLocale, $text);
+
+        if ($this->shouldUseResponsesApi()) {
+            return $this->translateWithResponsesApi($prompt);
+        }
+
+        return $this->translateWithChatCompletions($prompt);
+    }
+
+    /**
+     * Assemble the translation prompt from the configured (or default) template,
+     * interpolating the {source}, {target} and {text} tokens.
+     */
+    protected function buildPrompt(?string $sourceLocale, ?string $targetLocale, string $text): string
+    {
         $sourceLanguage = $this->getLanguage($sourceLocale);
         $targetLanguage = $this->getLanguage($targetLocale);
 
@@ -76,12 +91,20 @@ class OpenAiProvider extends Provider
         $prompt = empty($prompt)
             ? 'Translate the following text from {source} to {target}, keep html and only answer with the translated text, if you can not translate it, just return the text i\'ve provided you: {text}'
             : $prompt;
-        $prompt = str_replace(
+
+        return str_replace(
             ['{source}', '{target}', '{text}'],
             [$sourceLanguage ?? '[guess the language]', $targetLanguage, $text],
             $prompt
         );
+    }
 
+    /**
+     * Legacy Chat Completions path, used for all OpenAI-compatible providers and
+     * whenever no Vector Store is configured.
+     */
+    protected function translateWithChatCompletions(string $prompt): ?string
+    {
         $model = App::parseEnv($this->getModel());
 
         $body = [
@@ -95,15 +118,9 @@ class OpenAiProvider extends Provider
             'temperature' => floatval($this->getSetting('openAiTemperature', 0.5)),
         ];
 
-        try {
-            $response = $this->getClient()->post($this->getBaseUrl() . '/chat/completions', ['json' => $body]);
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
-            $responseBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : 'no response body';
-            MultiTranslator::error('OpenAI API error: ' . $responseBody);
-            throw $e;
-        }
+        $response = $this->postJson('/chat/completions', $body);
 
-        if ($response->getStatusCode() < 300) {
+        if ($response && $response->getStatusCode() < 300) {
             $contents = json_decode($response->getBody()->getContents());
 
             foreach ($contents->choices as $choice) {
@@ -112,6 +129,152 @@ class OpenAiProvider extends Provider
         }
 
         return null;
+    }
+
+    /**
+     * OpenAI Responses API path with File Search over a Vector Store.
+     * The interpolated prompt is sent as the request input; File Search retrieves
+     * terminology, glossaries and style guides from the configured Vector Store.
+     */
+    protected function translateWithResponsesApi(string $prompt): ?string
+    {
+        $body = [
+            'model' => App::parseEnv($this->getModel()),
+            'input' => $prompt,
+            'temperature' => floatval($this->getSetting('openAiTemperature', 0.5)),
+        ];
+
+        // Reference a centrally managed prompt (Prompt Management) when configured.
+        // The stored prompt carries the behaviour; the target language and text are
+        // still supplied dynamically through the request input above.
+        if (!empty($this->getPromptId())) {
+            $body['prompt'] = ['id' => $this->getPromptId()];
+            if (!empty($this->getPromptVersion())) {
+                $body['prompt']['version'] = $this->getPromptVersion();
+            }
+        }
+
+        // Enable File Search over the configured Vector Store when applicable.
+        // Request-level tools override any tools defined on a stored prompt, so the
+        // plugin's Vector Store augments the prompt's knowledge base.
+        if ($this->fileSearchEnabled()) {
+            $body['tools'] = [
+                [
+                    'type' => 'file_search',
+                    'vector_store_ids' => [$this->getVectorStoreId()],
+                ],
+            ];
+        }
+
+        $response = $this->postJson('/responses', $body);
+
+        if ($response && $response->getStatusCode() < 300) {
+            return $this->extractResponsesOutputText($response->getBody()->getContents());
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the assistant's text from a Responses API payload.
+     *
+     * The raw HTTP response has no top-level `output_text` helper (that is added by
+     * the official SDKs only), so we walk the `output[]` array, collect every
+     * `message` item's `output_text` content parts and concatenate them, skipping
+     * tool-call items such as `file_search_call`.
+     */
+    protected function extractResponsesOutputText(string $json): ?string
+    {
+        $contents = json_decode($json);
+
+        // Prefer the convenience field when a compatible endpoint does provide it.
+        if (!empty($contents->output_text) && is_string($contents->output_text)) {
+            return $contents->output_text;
+        }
+
+        if (empty($contents->output) || !is_array($contents->output)) {
+            return null;
+        }
+
+        $text = '';
+        foreach ($contents->output as $item) {
+            if (($item->type ?? null) !== 'message' || empty($item->content)) {
+                continue;
+            }
+            foreach ($item->content as $part) {
+                if (($part->type ?? null) === 'output_text' && isset($part->text)) {
+                    $text .= $part->text;
+                }
+            }
+        }
+
+        return $text !== '' ? $text : null;
+    }
+
+    /**
+     * POST a JSON body to a path relative to the configured base URL, logging and
+     * re-throwing any client error with the API's response body attached.
+     */
+    protected function postJson(string $path, array $body): ?\Psr\Http\Message\ResponseInterface
+    {
+        try {
+            return $this->getClient()->post($this->getBaseUrl() . $path, ['json' => $body]);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $responseBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : 'no response body';
+            MultiTranslator::error('OpenAI API error: ' . $responseBody);
+            throw $e;
+        }
+    }
+
+    /**
+     * Whether the Responses API should be used for this translation.
+     *
+     * Prompt Management (Prompt IDs) and File Search are OpenAI-specific features,
+     * so the Responses API is only used on the official api.openai.com host, and only
+     * when a Prompt ID is configured or File Search is enabled.
+     */
+    protected function shouldUseResponsesApi(): bool
+    {
+        if (!str_contains($this->getBaseUrl(), 'api.openai.com')) {
+            return false;
+        }
+
+        return !empty($this->getPromptId()) || $this->fileSearchEnabled();
+    }
+
+    /**
+     * Whether File Search over a Vector Store should be enabled: a Vector Store ID is
+     * configured and the "Enable File Search" switch is not set to off.
+     */
+    protected function fileSearchEnabled(): bool
+    {
+        return !empty($this->getVectorStoreId())
+            && $this->getSetting('openAiEnableFileSearch', 'auto') !== 'off';
+    }
+
+    /**
+     * Resolve the configured OpenAI Vector Store ID (with env var support).
+     */
+    protected function getVectorStoreId(): string
+    {
+        return trim(App::parseEnv($this->getSetting('openAiVectorStoreId', '')) ?? '');
+    }
+
+    /**
+     * Resolve the configured OpenAI Prompt ID for Prompt Management (with env var support).
+     */
+    protected function getPromptId(): string
+    {
+        return trim(App::parseEnv($this->getSetting('openAiPromptId', '')) ?? '');
+    }
+
+    /**
+     * Resolve the optional stored prompt version. Empty means OpenAI uses the
+     * currently published version.
+     */
+    protected function getPromptVersion(): string
+    {
+        return trim(App::parseEnv($this->getSetting('openAiPromptVersion', '')) ?? '');
     }
 
     /**

--- a/src/providers/OpenAiProvider.php
+++ b/src/providers/OpenAiProvider.php
@@ -142,29 +142,13 @@ class OpenAiProvider extends Provider
             'model' => App::parseEnv($this->getModel()),
             'input' => $prompt,
             'temperature' => floatval($this->getSetting('openAiTemperature', 0.5)),
-        ];
-
-        // Reference a centrally managed prompt (Prompt Management) when configured.
-        // The stored prompt carries the behaviour; the target language and text are
-        // still supplied dynamically through the request input above.
-        if (!empty($this->getPromptId())) {
-            $body['prompt'] = ['id' => $this->getPromptId()];
-            if (!empty($this->getPromptVersion())) {
-                $body['prompt']['version'] = $this->getPromptVersion();
-            }
-        }
-
-        // Enable File Search over the configured Vector Store when applicable.
-        // Request-level tools override any tools defined on a stored prompt, so the
-        // plugin's Vector Store augments the prompt's knowledge base.
-        if ($this->fileSearchEnabled()) {
-            $body['tools'] = [
+            'tools' => [
                 [
                     'type' => 'file_search',
                     'vector_store_ids' => [$this->getVectorStoreId()],
                 ],
-            ];
-        }
+            ],
+        ];
 
         $response = $this->postJson('/responses', $body);
 
@@ -227,29 +211,23 @@ class OpenAiProvider extends Provider
     }
 
     /**
-     * Whether the Responses API should be used for this translation.
+     * Whether the Responses API (with File Search) should be used for this translation.
      *
-     * Prompt Management (Prompt IDs) and File Search are OpenAI-specific features,
-     * so the Responses API is only used on the official api.openai.com host, and only
-     * when a Prompt ID is configured or File Search is enabled.
+     * File Search is an OpenAI-specific feature, so it is only enabled when a Vector
+     * Store ID is configured, the "Enable File Search" switch is not off, and the
+     * endpoint is the official api.openai.com host.
      */
     protected function shouldUseResponsesApi(): bool
     {
-        if (!str_contains($this->getBaseUrl(), 'api.openai.com')) {
+        if (empty($this->getVectorStoreId())) {
             return false;
         }
 
-        return !empty($this->getPromptId()) || $this->fileSearchEnabled();
-    }
+        if ($this->getSetting('openAiEnableFileSearch', 'auto') === 'off') {
+            return false;
+        }
 
-    /**
-     * Whether File Search over a Vector Store should be enabled: a Vector Store ID is
-     * configured and the "Enable File Search" switch is not set to off.
-     */
-    protected function fileSearchEnabled(): bool
-    {
-        return !empty($this->getVectorStoreId())
-            && $this->getSetting('openAiEnableFileSearch', 'auto') !== 'off';
+        return str_contains($this->getBaseUrl(), 'api.openai.com');
     }
 
     /**
@@ -258,23 +236,6 @@ class OpenAiProvider extends Provider
     protected function getVectorStoreId(): string
     {
         return trim(App::parseEnv($this->getSetting('openAiVectorStoreId', '')) ?? '');
-    }
-
-    /**
-     * Resolve the configured OpenAI Prompt ID for Prompt Management (with env var support).
-     */
-    protected function getPromptId(): string
-    {
-        return trim(App::parseEnv($this->getSetting('openAiPromptId', '')) ?? '');
-    }
-
-    /**
-     * Resolve the optional stored prompt version. Empty means OpenAI uses the
-     * currently published version.
-     */
-    protected function getPromptVersion(): string
-    {
-        return trim(App::parseEnv($this->getSetting('openAiPromptVersion', '')) ?? '');
     }
 
     /**

--- a/src/templates/_providers/openai/_settings.twig
+++ b/src/templates/_providers/openai/_settings.twig
@@ -63,24 +63,6 @@
 }) }}
 
 {{ forms.autosuggestfield({
-    label: 'Prompt ID',
-    name: 'openAiPromptId',
-    instructions: 'Optional. Reference a centrally managed prompt from OpenAI Prompt Management (e.g. `pmpt_...`). When set, the official OpenAI Responses API is used and the stored prompt provides the translation behaviour, while the source/target languages and text are still sent dynamically. Only applies to the official `api.openai.com` endpoint; ignored for OpenAI-compatible providers.',
-    suggestEnvVars: true,
-    value: settings.openAiPromptId ?? '',
-    placeholder: 'pmpt_...',
-}) }}
-
-{{ forms.autosuggestfield({
-    label: 'Prompt version',
-    name: 'openAiPromptVersion',
-    instructions: 'Optional. Pin a specific version of the stored prompt. Leave empty to always use the currently published version.',
-    suggestEnvVars: true,
-    value: settings.openAiPromptVersion ?? '',
-    placeholder: '',
-}) }}
-
-{{ forms.autosuggestfield({
     label: 'Vector Store ID',
     name: 'openAiVectorStoreId',
     instructions: 'Optional. Enter an OpenAI Vector Store ID (e.g. `vs_...`) to retrieve terminology, glossaries and style guides via File Search. When set, the official OpenAI Responses API is used instead of Chat Completions. Only applies to the official `api.openai.com` endpoint; ignored for OpenAI-compatible providers.',

--- a/src/templates/_providers/openai/_settings.twig
+++ b/src/templates/_providers/openai/_settings.twig
@@ -62,6 +62,45 @@
     value: settings.openAiPrompt ?? '',
 }) }}
 
+{{ forms.autosuggestfield({
+    label: 'Prompt ID',
+    name: 'openAiPromptId',
+    instructions: 'Optional. Reference a centrally managed prompt from OpenAI Prompt Management (e.g. `pmpt_...`). When set, the official OpenAI Responses API is used and the stored prompt provides the translation behaviour, while the source/target languages and text are still sent dynamically. Only applies to the official `api.openai.com` endpoint; ignored for OpenAI-compatible providers.',
+    suggestEnvVars: true,
+    value: settings.openAiPromptId ?? '',
+    placeholder: 'pmpt_...',
+}) }}
+
+{{ forms.autosuggestfield({
+    label: 'Prompt version',
+    name: 'openAiPromptVersion',
+    instructions: 'Optional. Pin a specific version of the stored prompt. Leave empty to always use the currently published version.',
+    suggestEnvVars: true,
+    value: settings.openAiPromptVersion ?? '',
+    placeholder: '',
+}) }}
+
+{{ forms.autosuggestfield({
+    label: 'Vector Store ID',
+    name: 'openAiVectorStoreId',
+    instructions: 'Optional. Enter an OpenAI Vector Store ID (e.g. `vs_...`) to retrieve terminology, glossaries and style guides via File Search. When set, the official OpenAI Responses API is used instead of Chat Completions. Only applies to the official `api.openai.com` endpoint; ignored for OpenAI-compatible providers.',
+    suggestEnvVars: true,
+    value: settings.openAiVectorStoreId ?? '',
+    placeholder: 'vs_...',
+}) }}
+
+{{ forms.selectField({
+    label: "Enable File Search",
+    instructions: "Controls the Vector Store File Search. 'Auto' enables it whenever a Vector Store ID is configured on the official OpenAI endpoint. 'Off' forces the legacy Chat Completions API even when a Vector Store ID is set.",
+    id: "openAiEnableFileSearch",
+    name: "openAiEnableFileSearch",
+    value: settings.openAiEnableFileSearch ?? 'auto',
+    options: [
+        {'label': 'Auto', 'value': 'auto'},
+        {'label': 'Off', 'value': 'off'},
+    ],
+}) }}
+
 {{ forms.textfield({
     label: 'API temperature',
     name: 'openAiTemperature',


### PR DESCRIPTION
This pull request adds the ability to specify an OpenAI Vector Store ID. When combined with a custom prompt, this allows you to specifically use a glossary or other documents in the store for translation. Globally, the setting can be controlled via “Enable File Search” (auto/off) to target either the Completion API (the previous default) or the Response API (when a Vector Store ID is specified).